### PR TITLE
Github Issue axelpale/genversion#15

### DIFF
--- a/lib/genversion.js
+++ b/lib/genversion.js
@@ -65,6 +65,13 @@ exports.check = (targetPath, opts, callback) => {
         return callback(null, true, false, false)
       }
 
+      // Issue axelpale/genversion#15
+      // Remove all the CR characters inserted by git on clone/checkout
+      // when git configuration has core.autocrlf=true
+      while (fileContent.indexOf('\r') >= 0) {
+        fileContent = fileContent.replace(/\r/,'');
+      }
+
       if (fileContent !== referenceContent) {
         // The file is created by genversion but has outdated content
         return callback(null, true, true, false)


### PR DESCRIPTION
Issue #15 : Affects only Windows environment with git configuration core.autocrlf=true.

Remove all the CR characters before the --check-only source file comparison.

The CR characters are inserted by git on clone/checkout when git configuration has core.autocrlf=true .

Affected Environment: Windows