### PR TITLE
Added support for backticks in generated code

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Directly from `$ genversion --help`:
       -v, --verbose        increased output verbosity
       -s, --semi           use semicolons in generated code
       -d, --double         use double quotes in generated code
+      -b, --backtick       use backticks in generated code
       -e, --es6            use es6 syntax in generated code
       -u, --strict         add "use strict" in generated code
       -p, --source <path>  search for package.json along a custom path
@@ -112,6 +113,10 @@ End each generated line of code with a semicolon as required by some style guide
 ### -d, --double
 
 Use double quotes `"` instead of single quotes `'` as required by some style guides.
+
+### -b, --backtick
+
+Use backticks `` ` `` instead of single `'` or double `"` quotes as required by some style guides.
 
 ### -e, --es6
 
@@ -157,6 +162,7 @@ Check if it is possible to generate the version module into `targetPath`.
   - *source:* optional string. An absolute or relative path to a file or directory. Genversion searches for the source package.json along this path. Defaults to the value of `targetPath`.
   - *useSemicolon:* optional boolean. Defaults to `false`.
   - *useDoubleQuotes:* optional boolean. Defaults to `false`.
+  - *useBackticks:* optional boolean. Defaults to `false`.
   - *useEs6Syntax:* optional boolean. Defaults to `false`.
   - *useStrict:* optional boolean. Defaults to `false`.
 - *callback:* function (err, doesExist, isByGenversion, isUpToDate), where:
@@ -189,6 +195,7 @@ Read the version property from the nearest `package.json` along the `targetPath`
   - *source:* optional string. An absolute or relative path to a file or directory. Genversion searches for the source package.json along this path. Defaults to the value of `targetPath`.
   - *useSemicolon:* optional boolean. Defaults to `false`.
   - *useDoubleQuotes:* optional boolean. Defaults to `false`.
+  - *useBackticks:* optional boolean. Defaults to `false`.
   - *useEs6Syntax:* optional boolean. Defaults to `false`.
   - *useStrict:* optional boolean. Defaults to `false`.
 - *callback:* function (err, version). Parameter *version* is the version string read from `package.json`. Parameter *err* is non-null if `package.json` cannot be found, its version is not a string, or writing the version module fails.
@@ -264,6 +271,7 @@ To configure VSCode debugger for genversion development, create a file `.vscode/
       "args": [
         "--semi",
         "--double",
+        "--backtick",
         "--es6",
         "--strict",
         "--check-only",

--- a/bin/genversion.js
+++ b/bin/genversion.js
@@ -15,6 +15,7 @@ program
   .option('-v, --verbose', 'increased output verbosity')
   .option('-s, --semi', 'use semicolons in generated code')
   .option('-d, --double', 'use double quotes in generated code')
+  .option('-b, --backtick', 'use backticks in generated code')
   .option('-e, --es6', 'use es6 syntax in generated code')
   .option('-u, --strict', 'add "use strict" in generated code')
   .option('-p, --source <path>', 'search for package.json along a custom path')
@@ -31,6 +32,7 @@ program
     const opts = {
       useSemicolon: cliOpts.semi,
       useDoubleQuotes: cliOpts.double,
+      useBackticks: cliOpts.backtick,
       useEs6Syntax: cliOpts.es6,
       useStrict: cliOpts.strict,
       source: cliOpts.source

--- a/lib/genversion.js
+++ b/lib/genversion.js
@@ -103,6 +103,9 @@ exports.dry = (targetPath, opts, callback) => {
   //       useDoubleQuotes
   //         boolean. Set true to use double quotes in generated code
   //         instead of single quotes.
+  //       useBackticks
+  //         boolean. Set true to use backticks in generated code
+  //         instead of single or double quotes.
   //       useEs6Syntax
   //         boolean. Set true to use ES6 export syntax
   //       useStrict:
@@ -145,6 +148,10 @@ exports.dry = (targetPath, opts, callback) => {
 
   if (typeof opts.useDoubleQuotes !== 'boolean') {
     opts.useDoubleQuotes = false // default
+  }
+
+  if (typeof opts.useBackticks !== 'boolean') {
+    opts.useBackticks = false // default
   }
 
   if (typeof opts.useEs6Syntax !== 'boolean') {
@@ -205,6 +212,9 @@ exports.generate = (targetPath, opts, callback) => {
   //       useDoubleQuotes
   //         boolean. Set true to use double quotes in generated code
   //         instead of single quotes.
+  //       useBackticks
+  //         boolean. Set true to use backticks in generated code
+  //         instead of single or double quotes.
   //       useEs6Syntax
   //         boolean. Set true to use ES6 export syntax
   //       useStrict:

--- a/lib/versionTools.js
+++ b/lib/versionTools.js
@@ -20,6 +20,9 @@ exports.createContent = (version, opts) => {
   //     useDoubleQuotes
   //       boolean. Set true to use double quotes in generated code
   //       instead of single quotes.
+  //     useBackticks
+  //       boolean. Set true to use backticks in generated code
+  //       instead of single or double quotes.
   //     useEs6Syntax:
   //       boolean. True to use ES6 export syntax in generated code
   //     useStrict:
@@ -30,7 +33,9 @@ exports.createContent = (version, opts) => {
   //
   let content = SIGNATURE + '\n'
 
-  const Q = opts.useDoubleQuotes ? '"' : '\''
+  let Q = opts.useDoubleQuotes ? '"' : '\''
+  Q = opts.useBackticks ? '`' : Q
+
   const SEMI = opts.useSemicolon ? ';' : ''
 
   // In some cases 'use strict' is required in the file

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "command-line-test": "^1.0.10",
     "eslint": "^7.32.0",
     "fs-extra": "^10.0.1",
-    "mocha": "^8.4.0",
+    "mocha": "^10.2.0",
     "should": "^13.1.0",
     "standard": "^16.0.4"
   },

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -112,7 +112,7 @@ describe('genversion cli', () => {
     })
   })
 
-  describe('flags --es6 --semi --double --strict', () => {
+  describe('flags --es6 --semi --double --backtick --strict', () => {
     it('should allow --es6 flag', (done) => {
       const clit = new CliTest()
 
@@ -157,6 +157,38 @@ describe('genversion cli', () => {
 
         readTemp().should.equal(SIGNATURE +
           'module.exports = "' + pjson.version + '"\n')
+
+        return done()
+      })
+    })
+
+    it('should allow --backtick flag', (done) => {
+      const clit = new CliTest()
+
+      clit.exec(GENERATE_COMMAND + ' --backtick ' + P, (err, response) => {
+        if (err) {
+          console.error(err, response)
+          return
+        }
+
+        readTemp().should.equal(SIGNATURE +
+          'module.exports = `' + pjson.version + '`\n')
+
+        return done()
+      })
+    })
+
+    it('should have --backtick flag take precedence over --double flag', (done) => {
+      const clit = new CliTest()
+
+      clit.exec(GENERATE_COMMAND + ' --backtick --double ' + P, (err, response) => {
+        if (err) {
+          console.error(err, response)
+          return
+        }
+
+        readTemp().should.equal(SIGNATURE +
+          'module.exports = `' + pjson.version + '`\n')
 
         return done()
       })


### PR DESCRIPTION
I added support for backticks in generated code as those are required for some style guides. I also upgraded the version of mocha due to a vulnerability detected via `npm audit`. New tests were written and README documentation updated.